### PR TITLE
issue/57 サイドバーのユーザーアイコンが中心からズレているBug修正

### DIFF
--- a/src/components/layout/sidebar/user.tsx
+++ b/src/components/layout/sidebar/user.tsx
@@ -37,7 +37,7 @@ export function NavUser() {
                   <AvatarFallback className="rounded-lg">{user?.name?.slice(0, 2)}</AvatarFallback>
                 </Avatar>
               ) : (
-                <Avatar className="h-8 w-8 rounded-lg">
+                <Avatar className="h-8 w-8 rounded-lg mt-2 group-data-[collapsible=icon]:justify-center">
                   <User />
                 </Avatar>
               )}


### PR DESCRIPTION
# 概要
<!-- 変更内容の概要を簡潔に記述してください -->
サイドバーのユーザーアイコンが中心からズレていた問題を修正しました。
## 関連Issue
<!-- 関連するIssueがあれば記載してください -->
- Close # 

## 変更内容
<!-- 変更内容を具体的に記載してください -->
- 変更点1
- Avatarコンポーネントにmt-2とgroup-data-[collapsible=icon]:justify-centerを追加して、サイドバーが閉じた際にアイコンが中央揃えになるよう調整しました。

## スクリーンショット
<!-- UIの変更がある場合は、変更前後のスクリーンショットを添付してください -->

### 変更前
![image](https://github.com/user-attachments/assets/1cf48ef8-808e-4d26-939b-f695b51576d5)

### 変更後
![image](https://github.com/user-attachments/assets/d97d3330-5a96-44bb-97cf-37ed1daafd7a)

## 動作確認項目
<!-- 確認した項目にチェックを入れてください -->
- [ ✔] ローカル環境で動作確認済み
- [✔ ] 必要なテストを追加/更新済み
- [✔ ] Lintエラーがないことを確認済み

## レビュー時の注意点
<!-- レビュアーに特に見て欲しい点があれば記載してください -->
1．修正内容があっているか確認お願いします。
2．プルリクエストの方法や手順が正しいかどうか確認お願いします。

## その他
<!-- その他、補足事項があれば記載してください -->