### PR TITLE
#47 deleteCourseの実装

### DIFF
--- a/src/app/api/[[...route]]/courses/deleteCourse.ts
+++ b/src/app/api/[[...route]]/courses/deleteCourse.ts
@@ -1,0 +1,37 @@
+import { prisma } from "@/lib/prisma";
+import { zValidator } from "@hono/zod-validator";
+import { createFactory } from "hono/factory";
+import type { Session } from "next-auth";
+import { z } from "zod";
+import { withAdmin } from "~/middleware/auth";
+
+type Variables = {
+  session: Session;
+};
+
+const factory = createFactory<{ Variables: Variables }>();
+
+export const deleteCourse = factory.createHandlers(
+  withAdmin,
+  zValidator(
+    "param",
+    z.object({
+      course_id: z.string().cuid(),
+    }),
+  ),
+  async (c) => {
+    const { course_id } = c.req.valid("param");
+    try {
+      await prisma.course.delete({
+        where: {
+          id: course_id,
+        },
+      });
+      const message = `コースID:${course_id}のコースが削除されました`;
+      return c.json({ course_id, message }, 200);
+    } catch (error) {
+      console.error("コースの削除中にエラーが発生しました:", error);
+      return c.json({ error: "コースの削除中にエラーが発生しました", details: error as string }, 500);
+    }
+  },
+);

--- a/src/app/api/[[...route]]/courses/deleteCourse.ts
+++ b/src/app/api/[[...route]]/courses/deleteCourse.ts
@@ -4,6 +4,7 @@ import { createFactory } from "hono/factory";
 import type { Session } from "next-auth";
 import { z } from "zod";
 import { withAdmin } from "~/middleware/auth";
+import { recoverFromNotFound } from "~/utils";
 
 type Variables = {
   session: Session;
@@ -22,15 +23,21 @@ export const deleteCourse = factory.createHandlers(
   async (c) => {
     const { course_id } = c.req.valid("param");
     try {
-      await prisma.course.delete({
-        where: {
-          id: course_id,
-        },
-      });
-      const message = `コースID:${course_id}のコースが削除されました`;
-      return c.json({ course_id, message }, 200);
+      const course = await recoverFromNotFound(
+        prisma.course.delete({
+          where: {
+            id: course_id,
+          },
+        }),
+      );
+
+      if (!course) {
+        return c.notFound();
+      }
+
+      return c.body(null, 204);
     } catch (error) {
-      console.error("コースの削除中にエラーが発生しました:", error);
+      console.error(error);
       return c.json({ error: "コースの削除中にエラーが発生しました", details: error as string }, 500);
     }
   },

--- a/src/app/api/[[...route]]/courses/index.ts
+++ b/src/app/api/[[...route]]/courses/index.ts
@@ -1,13 +1,13 @@
 import { Hono } from "hono";
-import problems from "./problems";
-import { getCourseList } from "./getCourseList";
 import { createCourse } from "./createCourse";
+import { deleteCourse } from "./deleteCourse";
 import { getCourse } from "./getCourse";
+import { getCourseList } from "./getCourseList";
+import problems from "./problems";
 
 export const courses = new Hono()
   .route("/problems", problems)
-  .get("/", ...getCourseList)
   .post("/", ...createCourse)
-  .get("/:course_id", ...getCourse);
-
-
+  .delete("/:course_id", ...deleteCourse)
+  .get("/:course_id", ...getCourse)
+  .get("/", ...getCourseList);


### PR DESCRIPTION
# 概要
<!-- 変更内容の概要を簡潔に記述してください -->
#47 を実装しました。

## 関連Issue
<!-- 関連するIssueがあれば記載してください -->
- Close #47    

## 変更内容
<!-- 変更内容を具体的に記載してください -->
- DELETE /api/course/:course_id エントリポイントからコースを削除できるようにしました。

## スクリーンショット
<!-- UIの変更がある場合は、変更前後のスクリーンショットを添付してください -->

### 変更前

### 変更後

## 動作確認項目
<!-- 確認した項目にチェックを入れてください -->
- [x] ローカル環境で動作確認済み
- [ ] 必要なテストを追加/更新済み
- [x] Lintエラーがないことを確認済み


## レビュー時の注意点
<!-- レビュアーに特に見て欲しい点があれば記載してください -->

Lintエラーが起きたました。しかし、今回の変更範囲ではなかったので別のブランチで対応したほうがいいかなと思って放置しております。
pre-commitが通っていないときがいっときあったようなのでそれが原因なのかもしれません。(自分原因だったらすみません 🙏🏽 )

![image](https://github.com/user-attachments/assets/fa310080-0c3a-455c-bfeb-557777f05fe5)

## その他
<!-- その他、補足事項があれば記載してください -->
動作確認には以下のページの動作確認用コレクションを使いました(DataDreamersの人だけ参照可能)
よろしくおねがいします。
https://www.notion.so/Issue-47-1bd5ce60521880b2b9e5ffe216f4aff3
