### PR TITLE
コース管理画面に新規作成ボタンと作成ページを追加

### DIFF
--- a/src/app/manage/courses/new/page.tsx
+++ b/src/app/manage/courses/new/page.tsx
@@ -1,0 +1,12 @@
+import { CourseForm } from "@/features/manage/course/components/course-form";
+
+export default function CourseNewPage() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="mx-auto max-w-2xl">
+        <h1 className="mb-6 text-2xl font-bold">コースを新規作成</h1>
+        <CourseForm />
+      </div>
+    </div>
+  );
+}

--- a/src/app/manage/courses/page.tsx
+++ b/src/app/manage/courses/page.tsx
@@ -2,6 +2,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { client } from "@/lib/hono";
+import { Plus } from "lucide-react";
 import { cookies } from "next/headers";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -33,9 +34,17 @@ export default async function ManageCoursesPage() {
     <div className="container mx-auto px-4 py-8">
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-3xl font-bold">コース一覧</h1>
-        <Link href="/manage">
-          <Button variant="outline">管理トップに戻る</Button>
-        </Link>
+        <div className="flex gap-2">
+          <Link href="/manage/courses/new">
+            <Button>
+              <Plus />
+              新規作成
+            </Button>
+          </Link>
+          <Link href="/manage">
+            <Button variant="outline">管理トップに戻る</Button>
+          </Link>
+        </div>
       </div>
 
       <div className="rounded-md border">

--- a/src/app/manage/courses/page.tsx
+++ b/src/app/manage/courses/page.tsx
@@ -35,15 +35,15 @@ export default async function ManageCoursesPage() {
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-3xl font-bold">コース一覧</h1>
         <div className="flex gap-2">
-          <Link href="/manage/courses/new">
-            <Button>
+          <Button asChild>
+            <Link href="/manage/courses/new">
               <Plus />
               新規作成
-            </Button>
-          </Link>
-          <Link href="/manage">
-            <Button variant="outline">管理トップに戻る</Button>
-          </Link>
+            </Link>
+          </Button>
+          <Button asChild variant="outline">
+            <Link href="/manage">管理トップに戻る</Link>
+          </Button>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- 管理者用コース一覧 (`/manage/courses`) のヘッダーに「新規作成」ボタンを追加
- コース作成ページ `/manage/courses/new` を新設し、既存の `CourseForm` を作成モードで描画
- バックエンド API (`POST /api/courses`) と `CourseForm` の作成ロジックは既に存在していたため、UI のエントリポイントのみを追加

## Test plan
- [x] `/manage/courses` を開き、ヘッダー右側に「新規作成」ボタンが表示される
- [x] ボタンをクリックすると `/manage/courses/new` に遷移する
- [x] フォームにタイトル必須・説明・公開フラグが表示される
- [x] 必須項目を空のまま送信するとバリデーションエラーが出る
- [x] 有効な値で送信するとコースが作成され、`/manage/courses/{id}` にリダイレクトされる
- [x] 一覧に戻ると新しいコースが表示されている
- [x] 非管理者ユーザーで `/manage/courses/new` を直接開くと API 側 (`withAdmin`) で 403 になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)