### PR TITLE
Fix🐛: 挑戦画面の下部空白と ResizableHandle 配置を修正

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -285,7 +285,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "bg-white relative flex w-full flex-1 flex-col dark:bg-neutral-950",
+        "bg-white relative flex w-full flex-1 flex-col overflow-hidden dark:bg-neutral-950",
         "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className,
       )}

--- a/src/features/problems/components/programming-interface.tsx
+++ b/src/features/problems/components/programming-interface.tsx
@@ -202,9 +202,9 @@ export default function ProgrammingInterface({ problem, mode = "challenge" }: Pr
                       </Tabs>
                     </main>
                   </ResizablePanel>
+                  <ResizableHandle withHandle />
                   {/* 下部: コンソール領域 */}
                   <ResizablePanel defaultSize={30} minSize={5}>
-                    <ResizableHandle withHandle />
                     <ConsoleView
                       histories={executionHistories}
                       activeHistoryIndex={activeHistoryIndex}


### PR DESCRIPTION
## Summary
- `SidebarInset` の `<main>` に `overflow-hidden` を追加し、Flexbox の scroll size 計算で挑戦画面（`/students/problems/<id>/challenge`）の下部にスクロール可能な空白が出現する問題を根治
- `ResizableHandle` を `ResizablePanel` の外（Group 直下）に移動し、`react-resizable-panels` の規約に準拠。境目のハンドル表示とドラッグ resize を正常化

## Test plan
- [x] `/students/problems/<id>/challenge` で下部の空白が消えていること
- [x] Console と上部パネルの境目で resize ハンドルがドラッグできること
- [x] `/students/courses`, `/students/problems` の一覧でスクロール正常
- [x] `/manage/courses`, `/manage/problems`, `/profile` で長いコンテンツが正常表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)